### PR TITLE
Use vcpkg for boost-test dependency

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
 
-
     - name: Install boost-test
       env:
         REMOTE_STORE: "https://nuget.pkg.github.com/michaeltryby/index.json"
@@ -42,7 +41,7 @@ jobs:
         cmake -B.\build -DBUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME}}${{env.TOOL_CHAIN_PATH}} .
         cmake --build .\build --config DEBUG
 
-     -name: Unit Test
+    - name: Unit Test
       run: ctest -B.\build -C Debug --output-on-failure
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,11 +10,14 @@ env:
   OMP_NUM_THREADS: 1
   BUILD_HOME: build
   TEST_HOME: nrtests
+  PACKAGE_NAME:  vcpkg-export-20220826-200052.1.0.0
+  PKG_NAME: vcpkg-export-20220826-200052
 
 jobs:
   unit_test:
     name: Build and unit test
     runs-on: windows-2019
+    environment: testing
     defaults:
       run:
         shell: cmd
@@ -30,37 +33,21 @@ jobs:
         repository: michaeltryby/ci-tools
         path: ci-tools
 
-    - name: Add tar.exe
-      if: ${{ runner.os == 'Windows' }}
-      shell: pwsh
+    - name: Install boost-test
+      env:
+        REMOTE_STORE: "https://nuget.pkg.github.com/michaeltryby/index.json"
+        USERNAME: michaeltryby
       run: |
-          "C:\Program Files\Git\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-
-
-    - name: Cache boost
-      id: cache-boost
-      uses: actions/cache@v2
-      env:
-        cache_paths: |
-            C:/ProgramData/chocolatey/lib/boost-*
-            C:/local/boost_*
-        pkg_file_hash: ${{ hashFiles('**/windows/packages.config') }}
-      with:
-        path: ${{ env.cache_paths }}
-        key: ${{ runner.os }}-cache-boost-${{ env.pkg_file_hash }}
-        restore-keys: |
-          ${{ runner.os }}-cache-boost-
-          ${{ runner.os }}-cache-
-          ${{ runner.os }}-
-
-    - name: Install boost
-      if: steps.cache-boost.outputs.cache-hit != 'true'
-      env:
-        pkg_cmnd: choco install -y packages.config
-      run: ${{ env.pkg_cmnd }}
+        nuget sources add -Name github -Source ${{ env.REMOTE_STORE }} -Username ${{ env.USERNAME }} -Password ${{ secrets.ACCESS_TOKEN }}
+        nuget install ${{env.PKG_NAME}} -Source github
 
     - name: Build and unit test
-      run: make.cmd /t /g "Visual Studio 16 2019"
+      env:
+        TOOL_CHAIN_PATH: \scripts\buildsystems\vcpkg.cmake
+      run: |
+        cd build
+        cmake .. -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME_LONG}}\scripts\buildsystems\vcpkg.cmake
+        cmake --build .
 
 
   reg_test:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       env:
         TOOL_CHAIN_PATH: \scripts\buildsystems\vcpkg.cmake
       run: |
-        cmake -B.\build -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME_LONG}}${{env.TOOL_CHAIN_PATH}} .
+        cmake -B.\build -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME}}${{env.TOOL_CHAIN_PATH}} .
         cmake --build .\build --config DEBUG
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,17 +21,10 @@ jobs:
     defaults:
       run:
         shell: cmd
-        working-directory: ci-tools/windows
 
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-
-    - name: Checkout submodule
-      uses: actions/checkout@v2
-      with:
-        repository: michaeltryby/ci-tools
-        path: ci-tools
 
     - name: Install boost-test
       env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
         cmake --build .\build --config DEBUG
 
     - name: Unit Test
-      run: ctest -B.\build -C Debug --output-on-failure
+      run: ctest --test-dir .\build -C Debug --output-on-failure
 
 
   reg_test:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
 
+
     - name: Install boost-test
       env:
         REMOTE_STORE: "https://nuget.pkg.github.com/michaeltryby/index.json"
@@ -39,7 +40,7 @@ jobs:
         TOOL_CHAIN_PATH: \scripts\buildsystems\vcpkg.cmake
       run: |
         cd build
-        cmake .. -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME_LONG}}\scripts\buildsystems\vcpkg.cmake
+        cmake -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=..\${{env.PACKAGE_NAME_LONG}}${{env.TOOL_CHAIN_PATH}} ..
         cmake --build .
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,12 +35,15 @@ jobs:
         nuget sources add -Name github -Source ${{ env.REMOTE_STORE }} -Username ${{ env.USERNAME }} -Password ${{ secrets.ACCESS_TOKEN }}
         nuget install ${{env.PKG_NAME}} -Source github
 
-    - name: Build and unit test
+    - name: Build
       env:
         TOOL_CHAIN_PATH: \scripts\buildsystems\vcpkg.cmake
       run: |
-        cmake -B.\build -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME}}${{env.TOOL_CHAIN_PATH}} .
+        cmake -B.\build -DBUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME}}${{env.TOOL_CHAIN_PATH}} .
         cmake --build .\build --config DEBUG
+
+     -name: Unit Test
+      run: ctest -B.\build -C Debug --output-on-failure
 
 
   reg_test:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,9 +39,8 @@ jobs:
       env:
         TOOL_CHAIN_PATH: \scripts\buildsystems\vcpkg.cmake
       run: |
-        cd build
-        cmake -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=..\${{env.PACKAGE_NAME_LONG}}${{env.TOOL_CHAIN_PATH}} ..
-        cmake --build .
+        cmake -B.\build -DBUILD-TESTS=ON -DCMAKE_TOOLCHAIN_FILE=.\${{env.PACKAGE_NAME_LONG}}${{env.TOOL_CHAIN_PATH}} .
+        cmake --build .\build --config DEBUG
 
 
   reg_test:

--- a/extern/boost.cmake
+++ b/extern/boost.cmake
@@ -19,7 +19,6 @@ endif()
 
 find_package(
   Boost
-    REQUIRED
     COMPONENTS
         unit_test_framework
     )

--- a/extern/boost.cmake
+++ b/extern/boost.cmake
@@ -2,7 +2,7 @@
 # CMakeLists.txt - CMake configuration file for swmm-solver/extern
 #
 # Created: March 16, 2020
-# Updated: May 21, 2020
+# Updated: Oct 19, 2022
 #
 # Author: Michael E. Tryby
 #         US EPA - ORD/CESER
@@ -17,22 +17,13 @@ else()
 endif()
 
 
-# Environment variable "BOOST_ROOT_X_XX_X" points to local install location
-if(DEFINED ENV{BOOST_ROOT_1_74_0})
-    set(BOOST_ROOT $ENV{BOOST_ROOT_1_74_0})
-
-elseif(DEFINED ENV{BOOST_ROOT_1_72_0})
-    set(BOOST_ROOT $ENV{BOOST_ROOT_1_72_0})
-
-elseif(DEFINED ENV{BOOST_ROOT_1_67_0})
-    set(BOOST_ROOT $ENV{BOOST_ROOT_1_67_0})
-
-endif()
-
-
-find_package(Boost 1.67.0
+find_package(
+  Boost
+    REQUIRED
     COMPONENTS
         unit_test_framework
     )
 
-include_directories (${Boost_INCLUDE_DIRS})
+include_directories(
+    ${Boost_INCLUDE_DIRS}
+)


### PR DESCRIPTION
This PR does the following: 
 - Reduces boost-test load time using nuget package
 - https://github.com/michaeltryby/vcpkg-boost-example/packages/1614231