### PR TITLE
Precision loss when calculating the TotalDuration, as a result, the last report result may not be added in output file

### DIFF
--- a/src/solver/project.c
+++ b/src/solver/project.c
@@ -162,7 +162,9 @@ void project_readInput()
     else
     {
         // --- compute total duration of simulation in seconds
-        TotalDuration = floor((EndDateTime - StartDateTime) * SECperDAY);
+        double durationDate = EndDate - StartDate;
+        double durationTime = EndTime - StartTime;
+        TotalDuration = floor(durationDate * SECperDAY + durationTime * SECperDAY);
 
         // --- reporting step must be <= total duration
         if ( (double)ReportStep > TotalDuration )


### PR DESCRIPTION
When I am using the latest official SWMM 5.2.4 code, and I found there was a bug fix have not been merged to the root repository which was pushed to [https://github.com/pyswmm/Stormwater-Management-Model](https://github.com/pyswmm/Stormwater-Management-Model)

The original PR is https://github.com/pyswmm/Stormwater-Management-Model/pull/219, copy the details as below:

Precision loss when calculating the TotalDuration, as a result, the last report result may not be added in output file

## SWMM version: 5.1.013
## Reproduce Steps:
1.	Use the sample INP file “Example1.inp”, make some changes:
    *	END_TIME changes to *11:30* from 12:00
    *	REPORT_STEP changes to *00:30:00* from 01:00:00
2.	Open the changed "Example1.inp" file, then Run Simulation
3.	Pick up a subcatchment or node or link, and Create a Time Series Table, then you will find the result data of the END_TIME has not been listed in the table. The current last one is Days 1 Hours 11:00:00, but not 11:30:00.

## Analysis:
The Start/End Date and Time is stored as text in INP file, after parsing them from INP file, they will be converted to double values.


The EndTime “11:30:00’’ converts to 0.47916666666666669, when it is added with EndDate “01/02/1998” (35797.000000000000), the new EndDateTime is 35797.479166666664. 
Use the below method to calculate the TotalDuration, the result is 127799.0.
```
    TotalDuration        = floor((EndDateTime - StartDateTime) * SECperDAY);
```
From the INP file, the StartDateTime is 01/01/1998 00:00:00, and the EndDateTime is 01/02/1998 11:30:00. The duration is 1 day and 11:30:00, it has 127800 seconds. 

**1 second precision losses now!** So the last time result will never been reported in output file.

## Solution:
The precision loss usually happens when a large double value plus a small double value. So, we need to avoid such calculations.


Change the calculation method of TotalDuration to be:
```
        double durationDate = EndDate - StartDate;
        double durationTime = EndTime - StartTime;
        TotalDuration = floor(durationDate * SECperDAY + durationTime * SECperDAY);
```
