### PR TITLE
Fix Release build warnings to enable successful Release compilation.

### DIFF
--- a/src/outfile/CMakeLists.txt
+++ b/src/outfile/CMakeLists.txt
@@ -22,6 +22,18 @@ add_library(swmm-output
         errormanager.c
 )
 
+target_compile_options(swmm-output
+    PUBLIC
+        $<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:Release>>:
+            -U_FORTIFY_SOURCE
+            -D_FORTIFY_SOURCE=0
+        >
+        $<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:RelWithDebInfo>>:
+            -U_FORTIFY_SOURCE
+            -D_FORTIFY_SOURCE=0
+        >
+)
+
 target_include_directories(swmm-output
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -60,6 +60,14 @@ target_compile_options(swmm5
             $<$<CONFIG:Release>:/fp:fast>
             $<$<CONFIG:Release>:/Zi>
         >
+        $<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:Release>>:
+            -U_FORTIFY_SOURCE
+            -D_FORTIFY_SOURCE=0
+        >
+        $<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:RelWithDebInfo>>:
+            -U_FORTIFY_SOURCE
+            -D_FORTIFY_SOURCE=0
+        >
 )
 
 target_link_options(swmm5


### PR DESCRIPTION
Reason: GCC's _FORTIFY_SOURCE enforces checks on return values for functions like fread, fwrite, and gets, triggering warnings when return values are ignored. These warnings (not errors) are enforced in strict Release builds due to the warn_unused_result attribute. Fix: Explicitly cast the return value to void ((void)fread) to suppress the warning without implementing error handling. Alternative: Add compiler flags to disable the warning.